### PR TITLE
Open the quickfix window even when there are no errors

### DIFF
--- a/plugin/rubytest.vim
+++ b/plugin/rubytest.vim
@@ -66,7 +66,7 @@ function s:ExecTest(cmd)
 
     cex system(cmd)
     redraw!
-    copen
+    botright copen
 
     let &efm = s:oldefm
   else


### PR DESCRIPTION
Hi, thanks for the plugin.

When in quickfix mode, during the run of the test status line displays ":call <SNR>45_Run(2)", and if tests has no errors this message stays.

With this change, during the run, the status line will display the run command (ie. "Running... spring rake test test/controllers/topic_controller.rb") and when finished it'll open quickfix window even when no errors found, just to better indicate the outcome.
