### PR TITLE
Rename commands Run->RunTest, RubyTestRunLast->RubyLastRun to eliminate delay on executing RunteTestRun

### DIFF
--- a/plugin/rubytest.vim
+++ b/plugin/rubytest.vim
@@ -208,8 +208,8 @@ endif
 if !hasmapto('<Plug>RubyFileRun')
   map <unique> <Leader>T <Plug>RubyFileRun
 endif
-if !hasmapto('<Plug>RubyTestRunLast')
-  map <unique> <Leader>l <Plug>RubyTestRunLast
+if !hasmapto('<Plug>RubyLastRun')
+  map <unique> <Leader>l <Plug>RubyLastRun
 endif
 
 function s:IsRubyTest()
@@ -241,10 +241,10 @@ function s:RunLast()
   end
 endfunction
 
-noremap <unique> <script> <Plug>RubyTestRun <SID>Run
+noremap <unique> <script> <Plug>RubyTestRun <SID>RunTest
 noremap <unique> <script> <Plug>RubyFileRun <SID>RunFile
-noremap <unique> <script> <Plug>RubyTestRunLast <SID>RunLast
-noremap <SID>Run :call <SID>Run(1)<CR>
+noremap <unique> <script> <Plug>RubyLastRun <SID>RunLast
+noremap <SID>RunTest :call <SID>Run(1)<CR>
 noremap <SID>RunFile :call <SID>Run(2)<CR>
 noremap <SID>RunLast :call <SID>RunLast()<CR>
 


### PR DESCRIPTION
I've noticed that when I try to run one spec with `<leader>t`, I have ~1 second delay before the command is actually executed, and with full file spec with `<leader>T`, there is no delay.

After some experimenting I've found that renaming proposed by this PR removes the delay.

I'm not 100% sure why it happens and why renaming solves the problem, but it seems that it's because the name `RubyTestRun` is ambiguous and matches both `RubyTestRun` and `RubyTestRunLast`.

Feel free to just close this PR if you think it's inappropriate or this behaviour is not reproducible in environments others than mine.