### PR TITLE
Removal of default mappings for less intrusive installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ Installation
 
 Copy all files to your ~/.vim directory.
 
+Mappings
+--------
+
+This plugin sets [no default
+mappings](stevelosh.com/blog/2011/09/writing-vim-plugins/#mapping-keys-the-right-way).
+We suggest putting the following mappings in your vimrc:
+
+```
+autocmd FileType ruby map <Leader>t <Plug>RubyTestRun
+autocmd FileType ruby map <Leader>T <Plug>RubyFileRun
+autocmd FileType ruby map <Leader>l <Plug>RubyTestRunLast
+```
+
+(`<Leader>` is mapped to '\' by default in vim)
+
+The rest of this readme will assume you used these.
+
 Usage
 -----
 
@@ -20,8 +37,6 @@ $ cd <your rails/merb root>
 $ vim test/unit/user_test.rb
 ```
 (move cursor into a test case, press `<Leader>t`)
-
-(`<Leader>` is mapping to '\' by default in vim)
 
 Be default, the plugin will print output in terminal. You can change this behavior by putting this line in your vimrc file:
 
@@ -62,19 +77,6 @@ Placeholders:
 * `%s`: only for minitest, replaced by closest suite name (class whose name begin with 'Test'). This can be used to match test case more exactly:
 
     let g:rubytest_cmd_testcase = "ruby %p -n '%s#%c'"
-
-Default Key Bindings
---------------------
-
-* `<Leader>t`: run test case under cursor
-* `<Leader>T`: run all tests in file
-* `<Leader>l`: run the last test, from any buffer
-
-You can change default key bindings:
-
-    map <Leader>\ <Plug>RubyTestRun     " change from <Leader>t to <Leader>\
-    map <Leader>] <Plug>RubyFileRun     " change from <Leader>T to <Leader>]
-    map <Leader>/ <Plug>RubyTestRunLast " change from <Leader>l to <Leader>/
 
 Tip
 ---

--- a/plugin/rubytest.vim
+++ b/plugin/rubytest.vim
@@ -158,6 +158,7 @@ endfunction
 
 let s:test_patterns = {}
 let s:test_patterns['test'] = function('s:RunTest')
+let s:test_patterns['tc'] = function('s:RunTest')
 let s:test_patterns['spec'] = function('s:RunSpec')
 let s:test_patterns['\.feature$'] = function('s:RunFeature')
 
@@ -201,16 +202,6 @@ let s:test_case_patterns['feature'] = {'^\s*Scenario\( Outline\)\?:':function('s
 
 let s:save_cpo = &cpo
 set cpo&vim
-
-if !hasmapto('<Plug>RubyTestRun')
-  map <unique> <Leader>t <Plug>RubyTestRun
-endif
-if !hasmapto('<Plug>RubyFileRun')
-  map <unique> <Leader>T <Plug>RubyFileRun
-endif
-if !hasmapto('<Plug>RubyTestRunLast')
-  map <unique> <Leader>l <Plug>RubyTestRunLast
-endif
 
 function s:IsRubyTest()
   for pattern in keys(s:test_patterns)


### PR DESCRIPTION
In this pull I've removed all (3) default mappings of the plugin. Here's why I think this is preferable to having the default mappings:

First off, I read it a while back in [this article](http://stevelosh.com/blog/2011/09/writing-vim-plugins/#localize-mappings-and-settings). Long story short: It messes up people's default mappings. This happened to me after installing the vim-rubytest plugin. I was greeted with 3 errors messages on launching vim, saying I had could not remap the shortcuts I already have.

Since I only wanted the mappings in ruby-files, it is annoying I had to make global shortcuts just to get rid of the error messages when launching vim.

Anyway, I think this is a more sensible default behavior, but it would of course be a braking change, so I won't be mad if you decline ;) I've updated the readme to reflect the new behavior.

Oh yea, and I added support for test-files with the `tc_` prefix.
